### PR TITLE
Make DistributionPoint relative_name a set of NameAttribute

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1851,7 +1851,7 @@ X.509 Extensions
 
     .. attribute:: relative_name
 
-        :type: :class:`Name` or None
+        :type: ``frozenset`` of :class:`NameAttribute`, or None
 
         This field describes methods to retrieve the CRL relative to the CRL
         issuer. At most one of ``full_name`` or ``relative_name`` will be

--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -544,7 +544,11 @@ def _decode_crl_distribution_points(backend, cdps):
                 )
             # OpenSSL code doesn't test for a specific type for
             # relativename, everything that isn't fullname is considered
-            # relativename.
+            # relativename.  Per RFC 5280:
+            #
+            # DistributionPointName ::= CHOICE {
+            #      fullName                [0]      GeneralNames,
+            #      nameRelativeToCRLIssuer [1]      RelativeDistinguishedName }
             else:
                 rns = cdp.distpoint.name.relativename
                 rnum = backend._lib.sk_X509_NAME_ENTRY_num(rns)
@@ -558,7 +562,7 @@ def _decode_crl_distribution_points(backend, cdps):
                         _decode_x509_name_entry(backend, rn)
                     )
 
-                relative_name = x509.Name(attributes)
+                relative_name = frozenset(attributes)
 
         dist_points.append(
             x509.DistributionPoint(

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -20,7 +20,7 @@ from cryptography.hazmat.primitives import constant_time, serialization
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.x509.general_name import GeneralName, IPAddress, OtherName
-from cryptography.x509.name import Name
+from cryptography.x509.name import NameAttribute
 from cryptography.x509.oid import (
     CRLEntryExtensionOID, ExtensionOID, ObjectIdentifier
 )
@@ -437,8 +437,15 @@ class DistributionPoint(object):
                     "full_name must be a list of GeneralName objects"
                 )
 
-        if relative_name and not isinstance(relative_name, Name):
-            raise TypeError("relative_name must be a Name")
+        if (
+            relative_name and not (
+                isinstance(relative_name, frozenset) and
+                all(isinstance(x, NameAttribute) for x in relative_name)
+            )
+        ):
+            raise TypeError(
+                "relative_name must be a frozenset of NameAttribute objects"
+            )
 
         if crl_issuer:
             crl_issuer = list(crl_issuer)

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -1895,7 +1895,7 @@ class TestCertificateBuilder(object):
             x509.CRLDistributionPoints([
                 x509.DistributionPoint(
                     full_name=None,
-                    relative_name=x509.Name([
+                    relative_name=frozenset([
                         x509.NameAttribute(
                             NameOID.COMMON_NAME,
                             u"indirect CRL for indirectCRL CA3"

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -3127,7 +3127,7 @@ class TestDistributionPoint(object):
     def test_repr(self):
         dp = x509.DistributionPoint(
             None,
-            x509.Name([
+            frozenset([
                 x509.NameAttribute(NameOID.COMMON_NAME, u"myCN")
             ]),
             frozenset([x509.ReasonFlags.ca_compromise]),
@@ -3143,21 +3143,21 @@ class TestDistributionPoint(object):
         )
         if six.PY3:
             assert repr(dp) == (
-                "<DistributionPoint(full_name=None, relative_name=<Name([<Name"
-                "Attribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonName)"
-                ">, value='myCN')>])>, reasons=frozenset({<ReasonFlags.ca_comp"
-                "romise: 'cACompromise'>}), crl_issuer=[<DirectoryName(value=<"
-                "Name([<NameAttribute(oid=<ObjectIdentifier(oid=2.5.4.3, name="
-                "commonName)>, value='Important CA')>])>)>])>"
+                "<DistributionPoint(full_name=None, relative_name=frozenset({<"
+                "NameAttribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonN"
+                "ame)>, value='myCN')>}), reasons=frozenset({<ReasonFlags.ca_c"
+                "ompromise: 'cACompromise'>}), crl_issuer=[<DirectoryName(valu"
+                "e=<Name([<NameAttribute(oid=<ObjectIdentifier(oid=2.5.4.3, na"
+                "me=commonName)>, value='Important CA')>])>)>])>"
             )
         else:
             assert repr(dp) == (
-                "<DistributionPoint(full_name=None, relative_name=<Name([<Name"
-                "Attribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonName)"
-                ">, value=u'myCN')>])>, reasons=frozenset([<ReasonFlags.ca_com"
-                "promise: 'cACompromise'>]), crl_issuer=[<DirectoryName(value="
-                "<Name([<NameAttribute(oid=<ObjectIdentifier(oid=2.5.4.3, name"
-                "=commonName)>, value=u'Important CA')>])>)>])>"
+                "<DistributionPoint(full_name=None, relative_name=frozenset([<"
+                "NameAttribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonN"
+                "ame)>, value=u'myCN')>]), reasons=frozenset([<ReasonFlags.ca_"
+                "compromise: 'cACompromise'>]), crl_issuer=[<DirectoryName(val"
+                "ue=<Name([<NameAttribute(oid=<ObjectIdentifier(oid=2.5.4.3, n"
+                "ame=commonName)>, value=u'Important CA')>])>)>])>"
             )
 
 
@@ -3407,7 +3407,7 @@ class TestCRLDistributionPointsExtension(object):
         assert cdps == x509.CRLDistributionPoints([
             x509.DistributionPoint(
                 full_name=None,
-                relative_name=x509.Name([
+                relative_name=frozenset([
                     x509.NameAttribute(
                         NameOID.COMMON_NAME,
                         u"indirect CRL for indirectCRL CA3"


### PR DESCRIPTION
DistributionPoint relative_name is currently a Name but RFC 5280
defines it as RelativeDistinguishedName, i.e. a non-empty SET OF
name attributes.  Change the DistributionPoint relative_name
attribute to be a frozenset of NameAttribute instead of a Name.
